### PR TITLE
Bump proto-lens and http2-grpc-types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work/
 http2-server-grpc.cabal
+warp-grpc.cabal
 *~

--- a/package.yaml
+++ b/package.yaml
@@ -21,9 +21,9 @@ dependencies:
 - binary >= 0.8.5 && < 0.9
 - bytestring >= 0.10.8 && < 0.11
 - case-insensitive >= 1.2.0 && < 1.3
-- http2-grpc-types >= 0.3 && < 0.4
+- http2-grpc-types >= 0.3 && < 0.5
 - http-types >= 0.12 && < 0.13
-- proto-lens >= 0.3 && < 0.5
+- proto-lens >= 0.3 && < 0.6
 - wai >= 3.2 && < 3.3
 - warp >= 3.2.24 && < 3.3
 - warp-tls >= 3.2 && < 3.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,6 @@
-resolver: lts-12.6
+resolver: lts-13.17
 packages:
 - .
 extra-deps:
-- 'http2-grpc-types-0.3.0.0'
-- 'warp-3.2.24'
-- 'lens-labels-0.3.0.0'
-- 'proto-lens-0.4.0.0'
+- 'http2-grpc-types-0.4.0.0'
+- 'proto-lens-0.5.0.0'


### PR DESCRIPTION
lens-labels was removed in proto-lens-0.5.0.0